### PR TITLE
Pinned problematic libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 coloredlogs
-InstagramAPI
+InstagramAPI==1.0.2
 praw
-requests
-imageio==2.4.1
-moviepy
+requests==2.11.1
+imageio==2.1.2
+moviepy==0.2.3.2
 cryptography
 schedule


### PR DESCRIPTION
Should probably pin some of the libraries to prevent failures in the future. 
<img width="926" alt="image" src="https://user-images.githubusercontent.com/11235171/61420190-449a7c00-a8b6-11e9-9f1b-4ad950230a91.png">
